### PR TITLE
refactor: replace generic errors with `ParamsError` across protocol builders and tests

### DIFF
--- a/__tests__/DpiBuilder.test.ts
+++ b/__tests__/DpiBuilder.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { ConnectionMode, DpiBuilder } from '../src/index.js';
+import { ConnectionMode, DpiBuilder, ParamsError } from '../src/index.js';
 
 describe('DpiBuilder', () => {
 	it('should initialize with default buffer', () => {
@@ -52,7 +52,7 @@ describe('DpiBuilder', () => {
 		expect(builder.buffer[9]).toBe(0x25);
 
 		// Test throw for unsupported DPI
-		expect(() => builder.setDpiValue(1, 99999)).toThrow();
+		expect(() => builder.setDpiValue(1, 99999)).toThrow(ParamsError);
 	});
 
 	it('should update stage mask and high stage flags during build', () => {

--- a/__tests__/MacrosBuilder.test.ts
+++ b/__tests__/MacrosBuilder.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'bun:test';
-import { Button, ConnectionMode, FirmwareAction, MacroName, MacrosBuilder, macroTemplates } from '../src/index.js';
+import {
+	Button,
+	ConnectionMode,
+	ParamsError,
+	FirmwareAction,
+	MacroName,
+	MacrosBuilder,
+	macroTemplates,
+} from '../src/index.js';
 
 describe('MacrosBuilder', () => {
 	it('should initialize with default buffer', () => {
@@ -91,7 +99,7 @@ describe('MacrosBuilder', () => {
 		const builder = new MacrosBuilder();
 		// @ts-expect-error test
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		expect(() => builder.setMacro(99 as any, [0, 0, 0])).toThrow('Invalid button identifier: 99');
+		expect(() => builder.setMacro(99 as any, [0, 0, 0])).toThrow(ParamsError);
 	});
 
 	it('should initialize with custom options in constructor', () => {

--- a/src/core/AttackSharkX11.ts
+++ b/src/core/AttackSharkX11.ts
@@ -25,7 +25,7 @@ const VID = 0x1d57;
 const DEVICE_INTERFACE = 0x02;
 const INTERRUPT_ENDPOINT = 0x83;
 
-class AttackSharkX11 {
+export class AttackSharkX11 {
 	public readonly productId: number;
 	device: Device;
 	deviceInterface!: Interface;
@@ -104,10 +104,13 @@ class AttackSharkX11 {
 						new InterfaceError(
 							`Could not claim interface ${DEVICE_INTERFACE}. On Windows, you might need to use Zadig to install WinUSB driver for Interface ${DEVICE_INTERFACE}.`,
 							DEVICE_INTERFACE,
+							{ cause: e },
 						),
 					);
 				}
-				throw e;
+				return reject(
+					new InterfaceError(`Could not claim interface ${DEVICE_INTERFACE}`, DEVICE_INTERFACE, { cause: e }),
+				);
 			}
 
 			const interruptEndpoint = iface.endpoints.find((e) => e.address === INTERRUPT_ENDPOINT);
@@ -135,7 +138,11 @@ class AttackSharkX11 {
 		await new Promise<void>((resolve, reject) => {
 			this.deviceInterface.release(true, (err) => {
 				if (err) {
-					reject(new InterfaceError('Error releasing interface', this.deviceInterface.interfaceNumber));
+					reject(
+						new InterfaceError('Error releasing interface', this.deviceInterface.interfaceNumber, {
+							cause: err,
+						}),
+					);
 					return;
 				}
 
@@ -298,7 +305,7 @@ class AttackSharkX11 {
 			wValue: 0x0308,
 			wIndex: 2,
 		});
-		await delay(250);
+		await delay(250); // TODO: Take another look at the delays to use the shortest safe time
 
 		await this.controlTransfer({
 			data: secondPacket,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,29 +5,27 @@ export class DriverError extends Error {
 	}
 }
 
-export class TransferError extends DriverError {
-	constructor(
-		message: string,
-		public endpoint: number,
-		options?: { cause?: unknown },
-	) {
-		super(message, options);
-	}
-}
-
-export class ControlTransferError extends DriverError {}
-
+/**
+ * An error is thrown when the provided parameters are invalid or missing
+ */
 export class ParamsError extends DriverError {
 	constructor(
 		public paramName: string,
+		message?: string,
 		options?: { cause?: unknown },
 	) {
-		super(`The parameter ${paramName} is missing or is not of the desired type.`, options);
+		super(message ?? `The parameter ${paramName} is missing or is not of the desired type.`, options);
 	}
 }
 
+/**
+ * Generic error related to the USB device
+ */
 export class DeviceError extends DriverError {}
 
+/**
+ * This error is thrown when there is a failure to access or claim a USB interface
+ */
 export class InterfaceError extends DriverError {
 	constructor(
 		message: string,
@@ -38,4 +36,29 @@ export class InterfaceError extends DriverError {
 	}
 }
 
+/**
+ * Basic error causing data transfer failures
+ */
+export class TransferError extends DriverError {
+	constructor(
+		message: string,
+		public endpoint?: number,
+		options?: { cause?: unknown },
+	) {
+		super(message, options);
+	}
+}
+
+/**
+ * Specific error related to Control Transfers (USB) failures
+ */
+export class ControlTransferError extends TransferError {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, undefined, options);
+	}
+}
+
+/**
+ * An error is thrown when an operation exceeds the expected timeout
+ */
 export class TimeoutError extends DriverError {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './core/AttackSharkX11.js';
-export { default as AttackSharkX11 } from './core/AttackSharkX11.js';
+export * from './core/BaseProtocolBuilder.js';
 export * from './protocols/CustomMacroBuilder.js';
 export * from './protocols/DpiBuilder.js';
 export * from './protocols/MacrosBuilder.js';
@@ -8,3 +8,4 @@ export * from './protocols/UserPreferencesBuilder.js';
 export * from './types.js';
 export * from './utils/delay.js';
 export * from './logger/index.js';
+export * from './errors.js';

--- a/src/protocols/CustomMacroBuilder.ts
+++ b/src/protocols/CustomMacroBuilder.ts
@@ -1,4 +1,5 @@
 import type { BaseProtocolBuilder } from '../core/BaseProtocolBuilder.js';
+import { ParamsError } from '../errors.js';
 import { Button, type ConnectionMode } from '../types.js';
 import {
 	type KeyCode,
@@ -155,7 +156,8 @@ export class CustomMacroBuilder implements BaseProtocolBuilder {
 			return this;
 		}
 		if (times < 1 || times > 255) {
-			throw new Error(
+			throw new ParamsError(
+				'times',
 				'The number of loops must be at least 1 (0x01) and at most 255 (0xFF), regardless of the mode',
 			);
 		}
@@ -194,7 +196,7 @@ export class CustomMacroBuilder implements BaseProtocolBuilder {
 				macroTemplate = macroTemplates[MacroName.CUSTOM_MACRO_EXTRA_BUTTON_5];
 				break;
 			default:
-				throw new Error('Unsupported button');
+				throw new ParamsError('button', `Unsupported button for custom macro: ${button}`);
 		}
 
 		this.defineMacroButton.setMacro(button, macroTemplate);

--- a/src/protocols/DpiBuilder.ts
+++ b/src/protocols/DpiBuilder.ts
@@ -1,4 +1,5 @@
 import type { BaseProtocolBuilder } from '../core/BaseProtocolBuilder.js';
+import { ParamsError } from '../errors.js';
 import { DPI_STEP_MAP } from '../tables/dpi-map.js';
 import { ConnectionMode } from '../types.js';
 
@@ -44,7 +45,7 @@ export class DpiBuilder implements BaseProtocolBuilder {
 	public readonly bRequest: number = 0x09;
 	public readonly wValue: number = 0x0304;
 	public readonly wIndex: number = 2;
-	stages: [number, number, number, number, number, number] = [800, 1600, 2400, 3200, 5000, 22000];
+	private stages: [number, number, number, number, number, number] = [800, 1600, 2400, 3200, 5000, 22000];
 
 	// noinspection FunctionTooLongJS
 	constructor(options?: DpiBuilderOptions) {
@@ -183,7 +184,10 @@ export class DpiBuilder implements BaseProtocolBuilder {
 	 */
 	public setStages(stages: [number, number, number, number, number, number]): this {
 		if (!Array.isArray(stages) || stages.length !== this.stages.length)
-			throw new Error(`You need to pass the 6 DPI values; e.g.: [800, 1600, 2400, 3200, 5000, 22000]`);
+			throw new ParamsError(
+				'stages',
+				`You need to pass the 6 DPI values; e.g.: [800, 1600, 2400, 3200, 5000, 22000]`,
+			);
 
 		for (let i = 0; i < stages.length; i++) {
 			this.setDpiValue((i + 1) as StageIndex, stages[i] ?? 0x00);
@@ -208,9 +212,6 @@ export class DpiBuilder implements BaseProtocolBuilder {
 		const checksum = this.calculateChecksum();
 		this.buffer.writeUInt16BE(checksum, OFFSET.CHECKSUM_HIGH_BYTE);
 
-		// this.buffer[OFFSET.CHECKSUM_HIGH_BYTE] = (checksum >> 8) & 0xff;
-		// this.buffer[OFFSET.CHECKSUM_LOW_BYTE] = checksum & 0xff;
-
 		return mode === ConnectionMode.Wired ? this.buffer.subarray(0, OFFSET.CHECKSUM_LOW_BYTE + 1) : this.buffer;
 	}
 
@@ -230,7 +231,7 @@ export class DpiBuilder implements BaseProtocolBuilder {
 		const match = keys.find((k) => k >= dpi);
 
 		if (match === undefined) {
-			throw new Error(`Unsupported DPI: ${dpi}`);
+			throw new ParamsError('dpi', `Unsupported DPI: ${dpi}`);
 		}
 
 		return DPI_STEP_MAP[match] ?? 0x00;

--- a/src/protocols/MacrosBuilder.ts
+++ b/src/protocols/MacrosBuilder.ts
@@ -1,4 +1,5 @@
 import type { BaseProtocolBuilder } from '../core/BaseProtocolBuilder.js';
+import { ParamsError } from '../errors.js';
 import { Button, type ConnectionMode } from '../types.js';
 
 export type MacroTuple = readonly [FirmwareAction, Modifiers, KeyCode | number];
@@ -443,7 +444,7 @@ export class MacrosBuilder implements BaseProtocolBuilder {
 
 		const offset = BUTTON_OFFSET[internalButton];
 		if (offset === undefined) {
-			throw new Error(`Invalid button identifier: ${button}`);
+			throw new ParamsError('button', `Invalid button identifier: ${button}`);
 		}
 
 		this.buffer[offset] = firmwareAction;

--- a/src/protocols/PollingRateBuilder.ts
+++ b/src/protocols/PollingRateBuilder.ts
@@ -1,4 +1,5 @@
 import type { BaseProtocolBuilder } from '../core/BaseProtocolBuilder.js';
+import { ParamsError } from '../errors.js';
 import type { ConnectionMode } from '../types.js';
 
 export enum Rate {
@@ -69,6 +70,8 @@ export class PollingRateBuilder implements BaseProtocolBuilder {
 		const value = rateMap[rate];
 		if (value !== undefined) {
 			this.buffer[3] = value;
+		} else {
+			throw new ParamsError('rate', `Unsupported Polling Rate: ${rate}`);
 		}
 
 		return this;

--- a/src/protocols/UserPreferencesBuilder.ts
+++ b/src/protocols/UserPreferencesBuilder.ts
@@ -1,4 +1,5 @@
 import type { BaseProtocolBuilder } from '../core/BaseProtocolBuilder.js';
+import { ParamsError } from '../errors.js';
 import { ConnectionMode } from '../types.js';
 
 /**
@@ -268,7 +269,7 @@ export class UserPreferencesBuilder implements BaseProtocolBuilder {
 		deepSleepTime: 10,
 		keyResponse: 4,
 	};
-	public readonly buffer: Buffer;
+	readonly buffer: Buffer;
 	public readonly bmRequestType: number = 0x21;
 	public readonly bRequest: number = 0x09;
 	public readonly wValue: number = 0x0305;
@@ -320,7 +321,7 @@ export class UserPreferencesBuilder implements BaseProtocolBuilder {
 	 */
 	setDeepSleep(minutes: DeepSleepTime): this {
 		if (minutes < 1 || minutes > 60) {
-			throw new Error('the minutes of deep sleep should be in the range of 1 to 60');
+			throw new ParamsError('deepSleepTime', 'the minutes of deep sleep should be in the range of 1 to 60');
 		}
 		this.deepSleepMinutes = minutes;
 		this.updateIndex4();
@@ -334,7 +335,7 @@ export class UserPreferencesBuilder implements BaseProtocolBuilder {
 	 */
 	setLedSpeed(speed: LedSpeed): this {
 		if (speed < 1 || speed > 5) {
-			throw new Error('LED speed must be between 1 and 5');
+			throw new ParamsError('ledSpeed', 'LED speed must be between 1 and 5');
 		}
 		this.ledSpeed = speed;
 		this.updateIndex4();
@@ -361,7 +362,7 @@ export class UserPreferencesBuilder implements BaseProtocolBuilder {
 	 */
 	setSleep(minutes: SleepTime): this {
 		if (minutes < 0.5 || minutes > 30) {
-			throw new Error('Invalid sleep value (0.5–30 min)');
+			throw new ParamsError('sleepTime', 'Invalid sleep value (0.5–30 min)');
 		}
 		this.buffer[9] = Math.round(minutes * 2);
 		return this;
@@ -373,7 +374,7 @@ export class UserPreferencesBuilder implements BaseProtocolBuilder {
 	 */
 	setKeyResponse(ms: KeyResponse): this {
 		if (ms < 4 || ms > 50 || ms % 2 !== 0) {
-			throw new Error('Invalid value (use 4–50ms, step 2)');
+			throw new ParamsError('keyResponse', 'Invalid value (use 4–50ms, step 2)');
 		}
 
 		this.buffer[10] = (ms - 4) / 2 + 0x02;


### PR DESCRIPTION
Standardized error handling by introducing `ParamsError` for parameter validation in all protocol builders. Updated related test cases and exports to align with this change.